### PR TITLE
A small bug in planner logic

### DIFF
--- a/Assets/_Project/Scripts/GOAP/GoapPlanner.cs
+++ b/Assets/_Project/Scripts/GOAP/GoapPlanner.cs
@@ -77,7 +77,7 @@ public class GoapPlanner : IGoapPlanner {
             }
         }
         
-        return false;
+        return parent.Leaves.Count > 0;
     }
 }
 


### PR DESCRIPTION
Hi, Adam! Firstly, I want to thank you for your quality YouTube videos. I've learnt a lot from them. But I found a hard-to-spot bug in your GOAP example. If you look at the Planner's code in the FindPath method, you'll notice that when you add a new node to the parent’s leaves, that means what that node found a successful path, so in this case, FindPath should return true. I fixed that, but please check if I'm correct too.

I found this bug when I was experimenting with your GOAP code in my https://github.com/m039/CommonUnitySamples (in the develop branch). It appeared when an action has several preconditions and planner resolves them one after another. I also use and modify a lot of code from your videos in my https://github.com/m039/CommonUnityLibrary. You might found this interesting, too.